### PR TITLE
fix: add path separator and uppercase hex in Boot variable filename

### DIFF
--- a/src/tdvf.rs
+++ b/src/tdvf.rs
@@ -114,7 +114,7 @@ fn parse_boot_order(machine: &Machine) -> Result<(Vec<u8>, Vec<u16>)> {
 
 /// Loads boot variable data if the corresponding file exists
 fn load_boot_variable_if_exists(boot_entry_num: u16, machine: &Machine) -> Result<Option<Vec<u8>>> {
-    let filename = format!("{}Boot{:04}.bin", machine.path_boot_xxxx, boot_entry_num);
+    let filename = format!("{}/Boot{:04X}.bin", machine.path_boot_xxxx, boot_entry_num);
     // Try to read the file, return None if it doesn't exist
     match read_file_data(&filename) {
         Ok(data) => Ok(Some(data)),


### PR DESCRIPTION
Two bugs:
1. **Missing path separator:** `path_boot_xxxx` is resolved to a directory path without trailing `/`, producing paths like `/home/user/tdx_computationBoot000B.bin` instead of `/home/user/tdx_computation/Boot000B.bin`.
2. **Lowercase hex:** `{:04}` produces lowercase hex (`Boot000b.bin`), but the extraction script (`extract_config_files.py`) creates uppercase filenames (`Boot000B.bin`).

Both bugs cause Boot variable files to silently fail to load, resulting in incorrect RTMR0 computation for indirect boot.

**Fix:** `format!("{}/Boot{:04X}.bin", ...)`