### PR TITLE
ci: harden supply chain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+    - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6  # v1.16.1
+    - name: Cache cargo deps (cli)
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+      with:
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          cli/target/
+        key: cargo-cli-${{ runner.os }}-${{ hashFiles('cli/Cargo.lock') }}
+        restore-keys: |
+          cargo-cli-${{ runner.os }}-
     - run: cd cli && cargo build --verbose
 
   test:
@@ -33,11 +44,21 @@ jobs:
     # manual / on-demand.
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
-    - uses: Swatinem/rust-cache@v2
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+    - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6  # v1.16.1
+    - name: Cache cargo deps (lib)
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+      with:
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: cargo-lib-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+        restore-keys: |
+          cargo-lib-${{ runner.os }}-
     - name: Cache OVMF.fd
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
       with:
         path: tests/fixtures/OVMF.fd
         # Key on the fetch script's content so changes (new pin / new URL)
@@ -55,12 +76,22 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
-    - uses: Swatinem/rust-cache@v2
-    - uses: docker/setup-buildx-action@v3
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+    - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6  # v1.16.1
+    - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
+    - name: Cache cargo deps (lib)
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+      with:
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: cargo-lib-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+        restore-keys: |
+          cargo-lib-${{ runner.os }}-
     - name: Cache OVMF.fd
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
       with:
         path: tests/fixtures/OVMF.fd
         key: ovmf-fd-${{ hashFiles('tests/fetch_ovmf.sh') }}
@@ -77,17 +108,30 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-    - uses: actions/checkout@v4
-    
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+
+    - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6  # v1.16.1
+
+    - name: Cache cargo deps (cli)
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+      with:
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          cli/target/
+        key: cargo-cli-${{ runner.os }}-${{ hashFiles('cli/Cargo.lock') }}
+        restore-keys: |
+          cargo-cli-${{ runner.os }}-
 
     - name: Build release
       run: cd cli && cargo build --release
 
     - name: Create Release
-      uses: softprops/action-gh-release@v1
-      with:
-        files: |
-          cli/target/release/tdx-measure
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh release create "${GITHUB_REF_NAME}" \
+          cli/target/release/tdx-measure \
+          --title "${GITHUB_REF_NAME}" \
+          --generate-notes

--- a/src/acpi.rs
+++ b/src/acpi.rs
@@ -325,13 +325,23 @@ struct QemuPkg<'a> {
     /// Version handed to the source fetcher. Empty string == "let the fetcher
     /// pick the current main-archive version" (only meaningful for `main`).
     version: &'a str,
+    /// Immutable OCI digest of the base image (`sha256:...`).
+    image_digest: &'static str,
 }
 
 fn qemu_pkg_for<'a>(distribution: &str, version_override: Option<&'a str>) -> Result<QemuPkg<'a>> {
     // Pinned defaults for reproducibility; override via `--qemu-version`.
-    let (source, default_version): (&'static str, &'static str) = match distribution {
-        "ubuntu:25.04" => ("ppa",  "1:9.2.1+ds-1ubuntu4+tdx2.0~ppa2"),
-        "ubuntu:26.04" => ("main", "1:10.2.1+ds-1ubuntu4"),
+    let (source, default_version, image_digest): (&'static str, &'static str, &'static str) = match distribution {
+        "ubuntu:25.04" => (
+            "ppa",
+            "1:9.2.1+ds-1ubuntu4+tdx2.0~ppa2",
+            "sha256:27771fb7b40a58237c98e8d3e6b9ecdd9289cec69a857fccfb85ff36294dac20",
+        ),
+        "ubuntu:26.04" => (
+            "main",
+            "1:10.2.1+ds-1ubuntu4",
+            "sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64",
+        ),
         other => bail!(
             "Unsupported distribution: {other}. Supported: ubuntu:25.04, ubuntu:26.04"
         ),
@@ -339,6 +349,7 @@ fn qemu_pkg_for<'a>(distribution: &str, version_override: Option<&'a str>) -> Re
     Ok(QemuPkg {
         source,
         version: version_override.unwrap_or(default_version),
+        image_digest,
     })
 }
 
@@ -431,10 +442,11 @@ fn build_docker_image(
         ),
     }
 
+    let pinned_image = format!("{distribution}@{}", pkg.image_digest);
     let status = Command::new("docker")
         .arg("build")
         .args(["--progress", "plain", "--tag", IMAGE_NAME])
-        .arg("--build-arg").arg(format!("DISTRIBUTION={distribution}"))
+        .arg("--build-arg").arg(format!("DISTRIBUTION={pinned_image}"))
         .arg("--build-arg").arg(format!("QEMU_SOURCE={}", pkg.source))
         .arg("--build-arg").arg(format!("QEMU_VERSION={}", pkg.version))
         .arg("--build-arg").arg(format!("ACPI_TABLES_NAME={acpi_tables_name}"))
@@ -792,10 +804,14 @@ mod tests {
         let p = qemu_pkg_for("ubuntu:25.04", None).unwrap();
         assert_eq!(p.source, "ppa");
         assert_eq!(p.version, "1:9.2.1+ds-1ubuntu4+tdx2.0~ppa2");
+        assert!(p.image_digest.starts_with("sha256:"));
+        assert_eq!(p.image_digest.len(), "sha256:".len() + 64);
 
         let p = qemu_pkg_for("ubuntu:26.04", None).unwrap();
         assert_eq!(p.source, "main");
         assert_eq!(p.version, "1:10.2.1+ds-1ubuntu4");
+        assert!(p.image_digest.starts_with("sha256:"));
+        assert_eq!(p.image_digest.len(), "sha256:".len() + 64);
     }
 
     #[test]


### PR DESCRIPTION
- Pin every GitHub Action by full 40-char commit SHA per GitHub's hardening guide; record the resolved release in a trailing comment so reviewers / Dependabot can keep them current.

- Remove third-party action dependencies that aren't strictly necessary:
  * Swatinem/rust-cache -> first-party actions/cache (registry + git + target). Two cache keys (cargo-cli + cargo-lib) because the repo is two independent crates with their own Cargo.lock files. ~15-25s of cache-hit saving is modest given our small dep tree, but losing one third-party action is worth the extra YAML.
  * softprops/action-gh-release -> first-party `gh release create` (gh is pre-installed on every GitHub-hosted runner). Also bumps off the v1 alias that was still pointing at the abandoned v0.1.15 lineage.

- Pin the Ubuntu base image used by the patched-QEMU Docker build to its immutable OCI image-index digest. QemuPkg now carries an `image_digest` field and `build_docker_image` passes `<tag>@<sha256:...>` as the DISTRIBUTION build-arg. Refresh via `docker manifest inspect ubuntu:<rel>`.