### PR TITLE
Fix for issue:38 and a few enhancements.

### DIFF
--- a/Dockerfile.qemu-acpi-dump
+++ b/Dockerfile.qemu-acpi-dump
@@ -4,11 +4,15 @@
 ARG DISTRIBUTION=ubuntu:25.04
 FROM ${DISTRIBUTION}
 
-# QEMU_SOURCE selects how the source tarball is fetched:
+# QEMU_SOURCE selects how the source is fetched:
 #   "ppa"  -> pull-ppa-source from ppa:kobuk-team/tdx-release (Intel TDX QEMU build for 24.04/25.04)
 #   "main" -> pull-lp-source from the distribution's main archive
+#   "url"  -> download a source tarball from QEMU_URL and verify it against QEMU_SHA256
 ARG QEMU_SOURCE=ppa
 ARG QEMU_VERSION=
+# Only used when QEMU_SOURCE=url: source-tarball URL and its expected SHA-256 (hex).
+ARG QEMU_URL=
+ARG QEMU_SHA256=
 ARG ACPI_TABLES_NAME
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -21,7 +25,10 @@ RUN apt-get update && \
         libglib2.0-dev \
         meson \
         ninja-build \
-        python3-venv && \
+        python3-venv \
+        ca-certificates \
+        curl \
+        xz-utils && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -30,6 +37,14 @@ RUN if [ "$QEMU_SOURCE" = "ppa" ]; then \
         pull-ppa-source --ppa ppa:kobuk-team/tdx-release qemu ${QEMU_VERSION}; \
     elif [ "$QEMU_SOURCE" = "main" ]; then \
         pull-lp-source qemu ${QEMU_VERSION}; \
+    elif [ "$QEMU_SOURCE" = "url" ]; then \
+        if [ -z "$QEMU_URL" ] || [ -z "$QEMU_SHA256" ]; then \
+            echo "QEMU_SOURCE=url requires QEMU_URL and QEMU_SHA256"; exit 1; \
+        fi && \
+        curl -fSL -o /qemu-src.tar "$QEMU_URL" && \
+        echo "${QEMU_SHA256}  /qemu-src.tar" | sha256sum -c - && \
+        tar -xf /qemu-src.tar -C / && \
+        rm -f /qemu-src.tar; \
     else \
         echo "Unknown QEMU_SOURCE: $QEMU_SOURCE"; exit 1; \
     fi

--- a/README.md
+++ b/README.md
@@ -29,9 +29,17 @@ This project is a fork of dstack-mr from the [Dstack-TEE/dstack](https://github.
       --transcript <TRANSCRIPT>             Generate a human-readable transcript of all metadata files and write to the specified file
       --create-acpi-tables <DISTRIBUTION> [<QEMU_VERSION>]
                                             Generate ACPI tables for direct boot mode. Only valid with direct boot.
-                                            <DISTRIBUTION> in {ubuntu:25.04, ubuntu:26.04}.
+                                            <DISTRIBUTION> in {ubuntu:24.04, ubuntu:25.04, ubuntu:26.04}.
                                             <QEMU_VERSION> overrides the pinned QEMU source-package version for the given distribution
                                             (pass `""` to fetch the current main-archive tip).
+      --qemu-source-url <URL>               Build QEMU from the source tarball at <URL> (hash-verified against
+                                            --qemu-source-sha256) instead of the distribution's PPA/main package.
+                                            Only used with --create-acpi-tables; must be given with --qemu-source-sha256.
+      --qemu-source-sha256 <HEX>            Expected SHA-256 (hex) of the --qemu-source-url tarball.
+      --patch-kernel                        Apply QEMU-style kernel boot-params patching before measuring RTMR[1].
+                                            Default false: the kernel is measured as-is (Ubuntu 26.04 and later, whose
+                                            kernels are loaded via the EFI stub). Pass `--patch-kernel` for pre-26.04
+                                            guests (e.g. Ubuntu 24.04 / 25.04)
   -h, --help                                Print help
   -V, --version                             Print version
 ```
@@ -92,6 +100,7 @@ Create `metadata.json` file with the below metadata:
   - `netdevs`: list of strings, each emitted as `-netdev <value>`.
   - `devices`: list of strings, each emitted as `-device <value>`. **Order is part of the API contract**: QEMU's PCI auto-slot assignment iterates `-device` arguments in command-line order and picks the lowest free slot, so `devices` must be authored in the same order as the reference launch you are mirroring. A `slot=N` argument on a `pcie-root-port` is only a hint and shifts if the slot is already taken by an earlier auto-assigned device. Order within `globals` / `objects` / `netdevs` / `fw_cfg` does not influence the ACPI tables.
   - `fw_cfg`: list of strings, each emitted as `-fw_cfg <value>`.
+  - `serial`: value passed verbatim to `-serial`.
 
 - `direct`: Direct boot specific configuration used to compute RTMR[1] and RTMR[2]
   - `kernel`: Path to file (e.g., `vmlinuz`) of kernel image, which will be directly loaded and executed by OVMF.
@@ -109,19 +118,45 @@ These are calculated by the tool automatically.
 When `--create-acpi-tables` is passed, the tool builds a small Docker image that
 patches QEMU to dump `etc/acpi/tables` and exits before TD entry. This requires
 a working `docker` (with buildx) and, when `accel: "kvm"` is in effect, KVM on
-the host. Each supported distribution pins a known-good QEMU source version
-(`1:9.2.1+ds-1ubuntu4+tdx2.0~ppa2` for `ubuntu:25.04`, `1:10.2.1+ds-1ubuntu4`
-for `ubuntu:26.04`) so the same metadata + CLI produces the same ACPI bytes
-regardless of when the regen runs. Pass an explicit version as the second
-positional value of `--create-acpi-tables` to override the pin (e.g. to validate
-an SRU), or `""` to opt into whatever `pull-lp-source` currently picks from the
-main archive:
+the host. The base image is pinned by digest for each supported distribution.
+
+Supported `<DISTRIBUTION>` values and how QEMU is sourced:
+
+| Distribution  | QEMU source                              | Pinned QEMU version               |
+|---------------|------------------------------------------|-----------------------------------|
+| `ubuntu:24.04`| `kobuk-team/tdx-release` PPA             | `2:8.2.2+ds-0ubuntu1.4+tdx1.1`    |
+| `ubuntu:25.04`| `kobuk-team/tdx-release` PPA             | `1:9.2.1+ds-1ubuntu4+tdx2.0~ppa2` |
+| `ubuntu:26.04`| distribution main archive                | `1:10.2.1+ds-1ubuntu4`            |
+
+For 24.04/25.04/26.04 the pinned QEMU version means the same metadata + CLI produces
+the same ACPI bytes regardless of when the regen runs. Pass an explicit version
+as the second positional value of `--create-acpi-tables` to override the pin
+(e.g. to validate an SRU), or `""` to opt into whatever `pull-lp-source`
+currently picks from the main archive:
 
 ```
 --create-acpi-tables ubuntu:26.04                              # default pin
 --create-acpi-tables ubuntu:26.04 1:10.2.1+ds-1ubuntu5         # explicit version
 --create-acpi-tables ubuntu:26.04 ""                           # current main-archive tip
 ```
+
+#### Building QEMU from a source tarball (hash-verified)
+
+Instead of the distribution's PPA/main package, you can build QEMU inside the
+container from a specific upstream source tarball, verified against a SHA-256.
+This pins QEMU exactly (independent of the PPA/archive) and works with any
+supported base distribution. Both flags must be given together:
+
+```
+--create-acpi-tables ubuntu:24.04 \
+  --qemu-source-url https://download.qemu.org/qemu-9.2.1.tar.xz \
+  --qemu-source-sha256 <sha256-hex-of-the-tarball>
+```
+
+The container downloads the tarball, runs `sha256sum -c` against it (the build
+fails closed on any mismatch), and builds from it. The tarball may be
+`.tar.xz`/`.gz`/`.bz2` and must unpack to a top-level `qemu*/` directory
+(standard upstream layout).
 
 ### Indirect Boot
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -51,6 +51,12 @@ struct Cli {
     /// `pull-lp-source`'s current main-archive pick.
     #[arg(long, num_args = 1..=2, value_names = ["DISTRIBUTION", "QEMU_VERSION"])]
     create_acpi_tables: Option<Vec<String>>,
+
+    /// Apply QEMU-style kernel boot-params patching before measuring RTMR1.
+    /// Pass `--patch-kernel` for kernels before Ubuntu:26.04,
+    /// 26.04 and above kernels are loaded via the EFI stub and measured as-is.
+    #[arg(long, default_value_t = false)]
+    patch_kernel: bool,
 }
 
 /// Helper struct to resolve and store file paths
@@ -138,6 +144,7 @@ impl PathResolver {
         create_acpi_table: bool,
         distribution: &'a str,
         qemu_version: Option<&'a str>,
+        patch_kernel: bool,
     ) -> Machine<'a> {
         Machine::builder()
             .cpu_count(self.paths.cpu_count)
@@ -161,6 +168,7 @@ impl PathResolver {
             .create_acpi_table(create_acpi_table)
             .distribution(distribution)
             .maybe_qemu_version(qemu_version)
+            .patch_kernel(patch_kernel)
             .build()
     }
 }
@@ -226,6 +234,7 @@ fn process_measurements(config: &Cli, image_config: &ImageConfig) -> Result<()> 
         create_acpi_table,
         distribution,
         qemu_version,
+        config.patch_kernel,
     );
 
     // Measure

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -57,6 +57,16 @@ struct Cli {
     /// 26.04 and above kernels are loaded via the EFI stub and measured as-is.
     #[arg(long, default_value_t = false)]
     patch_kernel: bool,
+
+    /// Build QEMU from a source tarball at this URL (hash-verified against
+    /// --qemu-source-sha256) instead of the distribution's PPA/main package.
+    /// Only used with --create-acpi-tables; both flags must be given together.
+    #[arg(long, value_name = "URL")]
+    qemu_source_url: Option<String>,
+
+    /// Expected SHA-256 (hex) of the --qemu-source-url tarball.
+    #[arg(long, value_name = "HEX")]
+    qemu_source_sha256: Option<String>,
 }
 
 /// Helper struct to resolve and store file paths
@@ -145,6 +155,8 @@ impl PathResolver {
         distribution: &'a str,
         qemu_version: Option<&'a str>,
         patch_kernel: bool,
+        qemu_source_url: Option<&'a str>,
+        qemu_source_sha256: Option<&'a str>,
     ) -> Machine<'a> {
         Machine::builder()
             .cpu_count(self.paths.cpu_count)
@@ -169,6 +181,8 @@ impl PathResolver {
             .distribution(distribution)
             .maybe_qemu_version(qemu_version)
             .patch_kernel(patch_kernel)
+            .maybe_qemu_source_url(qemu_source_url)
+            .maybe_qemu_source_sha256(qemu_source_sha256)
             .build()
     }
 }
@@ -235,6 +249,8 @@ fn process_measurements(config: &Cli, image_config: &ImageConfig) -> Result<()> 
         distribution,
         qemu_version,
         config.patch_kernel,
+        config.qemu_source_url.as_deref(),
+        config.qemu_source_sha256.as_deref(),
     );
 
     // Measure

--- a/src/acpi.rs
+++ b/src/acpi.rs
@@ -383,6 +383,7 @@ fn build_qemu_args(qemu: Option<&QemuShape>, cpus: u8, memory: &str) -> Vec<OsSt
             for v in &q.netdevs { push(&mut args, "-netdev", v); }
             for v in &q.devices { push(&mut args, "-device", v); }
             for v in &q.fw_cfg  { push(&mut args, "-fw_cfg", v); }
+            if let Some(serial) = &q.serial { push(&mut args, "-serial", serial); }
         }
         None => {
             // Canonical direct-boot defaults: minimal args from
@@ -865,6 +866,7 @@ mod tests {
                 "virtio-rng-pci".into(),
             ],
             fw_cfg: vec!["name=opt/ovmf/X-PciMmio64Mb,string=262144".into()],
+            serial: None,
         };
         let args = build_qemu_args(Some(&shape), 8, "16384M")
             .into_iter()

--- a/src/acpi.rs
+++ b/src/acpi.rs
@@ -7,13 +7,14 @@
 //! This module provides functionality to load ACPI tables for QEMU from files.
 
 use anyhow::{anyhow, bail, Context, Result};
-use log::{info, warn};
-use std::ffi::{OsStr, OsString};
+use log::{info, warn, debug};
+use std::ffi::OsString;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::util::read_file_data;
-use crate::{ImageConfig, Machine, QemuShape};
+use crate::{BootConfig, ImageConfig, Machine, QemuShape};
 
 const DOCKERFILE_QEMU_ACPI_DUMP: &str = include_str!("../Dockerfile.qemu-acpi-dump");
 const CONTAINER_NAME: &str = "acpi-tables-generator";
@@ -31,18 +32,21 @@ pub struct Tables {
 
 impl Machine<'_> {
     pub fn build_tables(&self) -> Result<Tables> {
-        if self.direct_boot && self.create_acpi_table {
+        let tables  = if self.direct_boot && self.create_acpi_table {
             generate_acpi_tables(
                 self.metadata_path,
                 self.distribution,
                 self.qemu_version,
                 self.qemu_source_url,
                 self.qemu_source_sha256,
-            )?;
-        }
+            )?
+        } else {
+            read_file_data(self.acpi_tables)?
+        };
+        self.process_acpi_tables(tables)
+    }
 
-        let tables  = read_file_data(self.acpi_tables)?;
-
+    fn process_acpi_tables(&self, tables: Vec<u8>) -> Result<Tables> {
         let rsdp: Vec<u8> = if !self.rsdp.is_empty() {
             read_file_data(self.rsdp)?
         } else {
@@ -69,6 +73,26 @@ impl Machine<'_> {
             rsdp,
             loader,
         })
+    }
+
+    pub fn build_tables_with_boot_config(&self, boot_config: &BootConfig) -> Result<Tables> {
+        if self.direct_boot && self.create_acpi_table {
+            let maybe_acpi_tables_target =  if self.acpi_tables.is_empty() {
+                None
+            } else {
+                let acpi_tables_target = Path::new("").join(&boot_config.acpi_tables);
+                let acpi_tables_dir = acpi_tables_target
+                .parent()
+                .with_context(|| format!("acpi_tables has no parent dir: {}", acpi_tables_target.display()))?;
+                fs_err::create_dir_all(acpi_tables_dir)?;
+                Some(acpi_tables_target)
+            };
+
+            let tables = generate_acpi_tables_with_qemu_args(boot_config, self.distribution, self.qemu_version, self.qemu_source_url, self.qemu_source_sha256, maybe_acpi_tables_target.as_ref())?;
+            self.process_acpi_tables(tables)
+        } else {
+            Err(anyhow!("ACPI table can be generated only in `direct_boot` and when `create_acpi_table: true`"))
+        }
     }
 }
 
@@ -549,46 +573,74 @@ pub fn generate_acpi_tables(
     qemu_version: Option<&str>,
     qemu_source_url: Option<&str>,
     qemu_source_sha256: Option<&str>,
-) -> Result<()> {
-    let mut pkg = qemu_pkg_for(distribution, qemu_version)?;
-    // When a source URL + SHA-256 are supplied, build QEMU from that tarball
-    // (hash-verified) instead of the distribution's PPA/main package. Both must
-    // be provided together.
-    match (qemu_source_url, qemu_source_sha256) {
-        (Some(url), Some(sha256)) => {
-            pkg.source = "url";
-            pkg.url = Some(url);
-            pkg.sha256 = Some(sha256);
-        }
-        (Some(_), None) | (None, Some(_)) => bail!(
-            "--qemu-source-url and --qemu-source-sha256 must be provided together"
-        ),
-        (None, None) => {}
-    }
+) -> Result<Vec<u8>> {
 
     let raw_metadata = fs_err::read_to_string(metadata_path)
         .context("Failed to read metadata.json for ACPI generation")?;
     let image_config: ImageConfig = serde_json::from_str(&raw_metadata)
         .context("Failed to parse metadata.json for ACPI generation")?;
-    let boot_config = image_config
+    let mut boot_config = image_config
         .boot_config
-        .as_ref()
+        .clone()
         .context("boot_config is required to generate ACPI tables")?;
     let bios = resolve_metadata_path(metadata_path, &boot_config.bios)
         .canonicalize()
         .with_context(|| format!("BIOS file not found: {}", boot_config.bios))?;
     let acpi_tables_target = resolve_metadata_path(metadata_path, &boot_config.acpi_tables);
+
+    boot_config.bios = bios.display().to_string();
+
     let acpi_tables_dir = acpi_tables_target
         .parent()
         .with_context(|| format!("acpi_tables has no parent dir: {}", acpi_tables_target.display()))?;
     fs_err::create_dir_all(acpi_tables_dir)?;
-    let acpi_tables_name = acpi_tables_target
-        .file_name()
-        .and_then(OsStr::to_str)
-        .context("acpi_tables path must end with a filename")?;
+    generate_acpi_tables_with_qemu_args(&boot_config, distribution, qemu_version, qemu_source_url, qemu_source_sha256, Some(&acpi_tables_target))
+}
+
+/// Generates ACPI tables for direct boot by building and running a
+/// patched-QEMU Docker container. The patched QEMU writes the
+/// `etc/acpi/tables` blob it would have exposed via fw_cfg to
+/// `boot_config.acpi_tables` and exits before TD entry.
+pub fn generate_acpi_tables_with_qemu_args(
+    boot_config: &BootConfig,
+    distribution: &str,
+    maybe_qemu_version: Option<&str>,
+    maybe_qemu_source_url: Option<&str>,
+    maybe_qemu_source_sha256: Option<&str>,
+    maybe_acpi_tables_target: Option<&PathBuf>,
+) -> Result<Vec<u8>> {
+    let mut pkg = qemu_pkg_for(distribution, maybe_qemu_version)?;
+    // When a source URL + SHA-256 are supplied, build QEMU from that tarball
+    // (hash-verified) instead of the distribution's PPA/main package. Both must
+    // be provided together.
+    match (maybe_qemu_source_url, maybe_qemu_source_sha256) {
+        (Some(url), Some(sha256)) => {
+            pkg.source = "url";
+            pkg.url = Some(url);
+            pkg.sha256 = Some(sha256);
+        }
+        (Some(_), None) | (None, Some(_)) => {
+            bail!("--qemu-source-url and --qemu-source-sha256 must be provided together")
+        }
+        (None, None) => {}
+    }
+
+    let bios = Path::new(&boot_config.bios);
+    // Bind-mounted output dir must be writable by the container's non-root `qemu-user`.
+
+    let output_dir = tempfile::tempdir().context("Failed to create ACPI output dir")?;
+    fs_err::set_permissions(output_dir.path(), std::fs::Permissions::from_mode(0o777))?;
+    const DEFAULT_ACPI_TABLES_NAME: &str = "acpi-tables.bin";
+    let acpi_tables_name = DEFAULT_ACPI_TABLES_NAME;
+    let generated_acpi_tables = output_dir.path().join(acpi_tables_name);
+
+
     info!(
         "ACPI gen config: cpus={}, memory={}, bios={}, target={}",
-        boot_config.cpus, boot_config.memory, bios.display(), acpi_tables_target.display()
+        boot_config.cpus,
+        boot_config.memory,
+        bios.display(),
+        generated_acpi_tables.display(),
     );
     if let Some(q) = &boot_config.qemu {
         info!(
@@ -603,14 +655,18 @@ pub fn generate_acpi_tables(
         build_ctx.path().join("Dockerfile.qemu-acpi-dump"),
         DOCKERFILE_QEMU_ACPI_DUMP,
     )?;
-    build_docker_image(build_ctx.path(), distribution, &pkg, acpi_tables_name)?;
+    build_docker_image(
+        build_ctx.path(),
+        distribution,
+        &pkg,
+        acpi_tables_name,
+    )?;
 
-    // Bind-mounted output dir must be writable by the container's non-root `qemu-user`.
-    use std::os::unix::fs::PermissionsExt;
-    let output_dir = tempfile::tempdir().context("Failed to create ACPI output dir")?;
-    fs_err::set_permissions(output_dir.path(), std::fs::Permissions::from_mode(0o777))?;
-
-    let qemu_args = build_qemu_args(boot_config.qemu.as_ref(), boot_config.cpus, &boot_config.memory);
+    let qemu_args = build_qemu_args(
+        boot_config.qemu.as_ref(),
+        boot_config.cpus,
+        &boot_config.memory,
+    );
     let need_kvm = boot_config
         .qemu
         .as_ref()
@@ -618,19 +674,33 @@ pub fn generate_acpi_tables(
         .unwrap_or(true);
     let need_vhost_vsock = boot_config.qemu.is_some();
 
-    run_docker_container(&bios, output_dir.path(), &qemu_args, need_kvm, need_vhost_vsock)?;
+    run_docker_container(
+        &bios,
+        output_dir.path(),
+        &qemu_args,
+        need_kvm,
+        need_vhost_vsock,
+    )?;
 
-    // Move the produced ACPI tables into place; `fs::copy` would inherit the
+    // Move the generated_acpi_tables ACPI tables into place; `fs::copy` would inherit the
     // container's restrictive 0600 from the source, so widen to 0644 after.
-    let produced = output_dir.path().join(acpi_tables_name);
-    if !produced.exists() {
-        bail!("ACPI tables not found in container output: {}", produced.display());
+    if !generated_acpi_tables.exists() {
+        bail!(
+            "ACPI tables not found in container output: {}",
+            generated_acpi_tables.display()
+        );
     }
-    fs_err::copy(&produced, &acpi_tables_target)?;
-    fs_err::set_permissions(&acpi_tables_target, std::fs::Permissions::from_mode(0o644))?;
-    info!("ACPI tables written to: {}", acpi_tables_target.display());
+    if let Some(acpi_tables_target) = maybe_acpi_tables_target {
+        fs_err::copy(&generated_acpi_tables, &acpi_tables_target)?;
+        fs_err::set_permissions(&acpi_tables_target, std::fs::Permissions::from_mode(0o644))?;
+        info!("ACPI tables written to: {}", acpi_tables_target.display());
+    } else {
+        debug!("ACPI tables were not copied from the temporary file target");
+    }
 
-    Ok(())
+    let tables = fs_err::read(&generated_acpi_tables)?;
+
+    Ok(tables)
 }
 
 #[cfg(test)]

--- a/src/acpi.rs
+++ b/src/acpi.rs
@@ -76,22 +76,42 @@ impl Machine<'_> {
     }
 
     pub fn build_tables_with_boot_config(&self, boot_config: &BootConfig) -> Result<Tables> {
-        if self.direct_boot && self.create_acpi_table {
-            let maybe_acpi_tables_target =  if self.acpi_tables.is_empty() {
+        let mut acpi_tables_path = self.acpi_tables;
+        if acpi_tables_path.is_empty() {
+            acpi_tables_path = &boot_config.acpi_tables; // override if Machine::acpi_tables is empty.
+        }
+         let maybe_acpi_tables_target = if acpi_tables_path.is_empty() {
                 None
             } else {
-                let acpi_tables_target = Path::new("").join(&boot_config.acpi_tables);
-                let acpi_tables_dir = acpi_tables_target
-                .parent()
-                .with_context(|| format!("acpi_tables has no parent dir: {}", acpi_tables_target.display()))?;
+                let acpi_tables_target = Path::new("").join(acpi_tables_path);
+                let acpi_tables_dir = acpi_tables_target.parent().with_context(|| {
+                    format!(
+                        "acpi_tables has no parent dir: {}",
+                        acpi_tables_target.display()
+                    )
+                })?;
                 fs_err::create_dir_all(acpi_tables_dir)?;
                 Some(acpi_tables_target)
             };
-
-            let tables = generate_acpi_tables_with_qemu_args(boot_config, self.distribution, self.qemu_version, self.qemu_source_url, self.qemu_source_sha256, maybe_acpi_tables_target.as_ref())?;
+        let generate_tables = || {
+            let tables = generate_acpi_tables_with_qemu_args(
+                    boot_config,
+                    self.distribution,
+                    self.qemu_version,
+                    self.qemu_source_url,
+                    self.qemu_source_sha256,
+                    maybe_acpi_tables_target.as_ref(),
+                )?;
             self.process_acpi_tables(tables)
+        };
+        if self.create_acpi_table {
+            if self.direct_boot {
+                generate_tables()
+            } else {
+                Err(anyhow!("ACPI table cannot be generated for `indirect_boot`"))
+            }
         } else {
-            Err(anyhow!("ACPI table can be generated only in `direct_boot` and when `create_acpi_table: true`"))
+            generate_tables()
         }
     }
 }

--- a/src/acpi.rs
+++ b/src/acpi.rs
@@ -32,7 +32,13 @@ pub struct Tables {
 impl Machine<'_> {
     pub fn build_tables(&self) -> Result<Tables> {
         if self.direct_boot && self.create_acpi_table {
-            generate_acpi_tables(self.metadata_path, self.distribution, self.qemu_version)?;
+            generate_acpi_tables(
+                self.metadata_path,
+                self.distribution,
+                self.qemu_version,
+                self.qemu_source_url,
+                self.qemu_source_sha256,
+            )?;
         }
 
         let tables  = read_file_data(self.acpi_tables)?;
@@ -317,21 +323,31 @@ fn find_acpi_table(tables: &[u8], signature: &str) -> Result<(u32, u32, u32)> {
     bail!("Table not found: {signature}");
 }
 
-/// Describes how to fetch the QEMU source package for a given distribution.
+/// Describes how to fetch the QEMU source for a given distribution.
 struct QemuPkg<'a> {
     /// `ppa` -> `pull-ppa-source --ppa ppa:kobuk-team/tdx-release qemu $VERSION`
     /// `main` -> `pull-lp-source qemu $VERSION` (or latest in main when empty)
+    /// `url`  -> download a source tarball from `url` and verify it against `sha256`
     source: &'static str,
     /// Version handed to the source fetcher. Empty string == "let the fetcher
-    /// pick the current main-archive version" (only meaningful for `main`).
+    /// pick the current main-archive version" (only meaningful for `main`/`ppa`).
     version: &'a str,
     /// Immutable OCI digest of the base image (`sha256:...`).
     image_digest: &'static str,
+    /// For `source == "url"`: the QEMU source-tarball URL and its expected
+    /// SHA-256 (hex). Ignored for `ppa`/`main`.
+    url: Option<&'a str>,
+    sha256: Option<&'a str>,
 }
 
 fn qemu_pkg_for<'a>(distribution: &str, version_override: Option<&'a str>) -> Result<QemuPkg<'a>> {
     // Pinned defaults for reproducibility; override via `--qemu-version`.
     let (source, default_version, image_digest): (&'static str, &'static str, &'static str) = match distribution {
+        "ubuntu:24.04" => (
+            "ppa",
+            "2:8.2.2+ds-0ubuntu1.4+tdx1.1",
+            "sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54",
+        ),
         "ubuntu:25.04" => (
             "ppa",
             "1:9.2.1+ds-1ubuntu4+tdx2.0~ppa2",
@@ -343,13 +359,15 @@ fn qemu_pkg_for<'a>(distribution: &str, version_override: Option<&'a str>) -> Re
             "sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64",
         ),
         other => bail!(
-            "Unsupported distribution: {other}. Supported: ubuntu:25.04, ubuntu:26.04"
+            "Unsupported distribution: {other}. Supported: ubuntu:24.04, ubuntu:25.04, ubuntu:26.04"
         ),
     };
     Ok(QemuPkg {
         source,
         version: version_override.unwrap_or(default_version),
         image_digest,
+        url: None,
+        sha256: None,
     })
 }
 
@@ -437,6 +455,11 @@ fn build_docker_image(
             "QEMU source: {distribution} main archive ({})",
             if pkg.version.is_empty() { "latest" } else { pkg.version }
         ),
+        "url" => info!(
+            "QEMU source: tarball {} (sha256 {}) on {distribution}",
+            pkg.url.expect("Missing QEMU url for source type `url`"),
+            pkg.sha256.expect("Missing QEMU sha256 hash for source type `url`"),
+        ),
         other => info!(
             "QEMU source: {other} ({})",
             if pkg.version.is_empty() { "?" } else { pkg.version }
@@ -444,13 +467,18 @@ fn build_docker_image(
     }
 
     let pinned_image = format!("{distribution}@{}", pkg.image_digest);
-    let status = Command::new("docker")
-        .arg("build")
+    let mut cmd = Command::new("docker");
+    cmd.arg("build")
         .args(["--progress", "plain", "--tag", IMAGE_NAME])
         .arg("--build-arg").arg(format!("DISTRIBUTION={pinned_image}"))
         .arg("--build-arg").arg(format!("QEMU_SOURCE={}", pkg.source))
         .arg("--build-arg").arg(format!("QEMU_VERSION={}", pkg.version))
-        .arg("--build-arg").arg(format!("ACPI_TABLES_NAME={acpi_tables_name}"))
+        .arg("--build-arg").arg(format!("ACPI_TABLES_NAME={acpi_tables_name}"));
+    if pkg.source == "url" {
+        cmd.arg("--build-arg").arg(format!("QEMU_URL={}", pkg.url.expect("Missing QEMU url for source type `url`")));
+        cmd.arg("--build-arg").arg(format!("QEMU_SHA256={}", pkg.sha256.expect("Missing QEMU sha256 hash for source type `url`")));
+    }
+    let status = cmd
         .arg("--file").arg(dockerfile_dir.join("Dockerfile.qemu-acpi-dump"))
         .arg(dockerfile_dir)
         .status()
@@ -519,8 +547,24 @@ pub fn generate_acpi_tables(
     metadata_path: &Path,
     distribution: &str,
     qemu_version: Option<&str>,
+    qemu_source_url: Option<&str>,
+    qemu_source_sha256: Option<&str>,
 ) -> Result<()> {
-    let pkg = qemu_pkg_for(distribution, qemu_version)?;
+    let mut pkg = qemu_pkg_for(distribution, qemu_version)?;
+    // When a source URL + SHA-256 are supplied, build QEMU from that tarball
+    // (hash-verified) instead of the distribution's PPA/main package. Both must
+    // be provided together.
+    match (qemu_source_url, qemu_source_sha256) {
+        (Some(url), Some(sha256)) => {
+            pkg.source = "url";
+            pkg.url = Some(url);
+            pkg.sha256 = Some(sha256);
+        }
+        (Some(_), None) | (None, Some(_)) => bail!(
+            "--qemu-source-url and --qemu-source-sha256 must be provided together"
+        ),
+        (None, None) => {}
+    }
 
     let raw_metadata = fs_err::read_to_string(metadata_path)
         .context("Failed to read metadata.json for ACPI generation")?;
@@ -813,6 +857,17 @@ mod tests {
         assert_eq!(p.version, "1:10.2.1+ds-1ubuntu4");
         assert!(p.image_digest.starts_with("sha256:"));
         assert_eq!(p.image_digest.len(), "sha256:".len() + 64);
+
+    }
+
+    #[test]
+    fn qemu_pkg_for_supports_24_04_via_ppa() {
+        let p = qemu_pkg_for("ubuntu:24.04", None).unwrap();
+        assert_eq!(p.source, "ppa");
+        // 24.04 base image is pinned by digest for reproducibility.
+        assert!(p.image_digest.starts_with("sha256:"));
+        assert_eq!(p.image_digest.len(), "sha256:".len() + 64);
+        assert!(p.url.is_none() && p.sha256.is_none());
     }
 
     #[test]

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -92,12 +92,18 @@ fn patch_kernel(
     Ok(kd)
 }
 
-/// Measures a QEMU-patched TDX kernel image from file paths (for direct boot).
+/// Measures a TDX kernel image from file paths (for direct boot).
+///
+/// When `patch` is true (Ubuntu 25.04 / OVMF 2025.02), the kernel boot-params
+/// header is patched the way QEMU does before load and the patched image is
+/// measured. For 26.04 and later (OVMF >= 2025.05) the kernel is loaded via the
+/// EFI stub on the raw PE image, so it is measured as-is.
 pub(crate) fn measure_rtmr1_direct(
     kernel_path: &str,
     initrd_path: &str,
     mem_size: u64,
     acpi_data_size: u32,
+    should_patch_kernel: bool,
 ) -> Result<Vec<u8>> {
 
     // Read kernel and initrd files
@@ -105,9 +111,14 @@ pub(crate) fn measure_rtmr1_direct(
     let initrd_data = fs::read(initrd_path).context("Failed to read initrd file")?;
     let initrd_size = initrd_data.len() as u32;
 
-    // Patch kernel to mimic QEMU's behavior
-    let kd = patch_kernel(&kernel_data, initrd_size, mem_size, acpi_data_size)
-        .context("Failed to patch kernel")?;
+    // Patch the kernel to mimic QEMU's behavior only for the legacy firmware
+    // profile; newer firmware measures the kernel image as-is.
+    let kd = if should_patch_kernel {
+        patch_kernel(&kernel_data, initrd_size, mem_size, acpi_data_size)
+            .context("Failed to patch kernel")?
+    } else {
+        kernel_data
+    };
     let kernel_hash = authenticode_sha384_hash(&kd).context("Failed to compute kernel hash")?;
 
     // Compute RTMR1 log

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
-use bon::Builder;
 /*
  * Copyright (c) 2025 Phala Network
  * Copyright (c) 2025 Tinfoil Inc
  * Copyright (c) 2025 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
+use bon::Builder;
 use serde::{Deserialize, Serialize};
 use serde_human_bytes as hex_bytes;
 use anyhow::{anyhow, Result};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use bon::Builder;
 /*
  * Copyright (c) 2025 Phala Network
  * Copyright (c) 2025 Tinfoil Inc
@@ -38,7 +39,7 @@ pub struct TdxMeasurements {
 }
 
 /// Common boot configuration (platform-specific)
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Builder)]
 pub struct BootConfig {
     pub cpus: u8,
     pub memory: String,
@@ -99,7 +100,7 @@ pub struct IndirectBoot {
 }
 
 /// Complete image configuration
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Builder)]
 pub struct ImageConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub boot_config: Option<BootConfig>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,10 @@ pub struct QemuShape {
     pub devices: Vec<String>,
     #[serde(default)]
     pub fw_cfg: Vec<String>,
+    /// Value for QEMU's `-serial` flag (e.g. `"stdio"`, `"null"`). When omitted,
+    /// no `-serial` flag is passed.
+    #[serde(default)]
+    pub serial: Option<String>,
 }
 
 fn default_cpu() -> String { "host".to_string() }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -34,6 +34,7 @@ pub struct Machine<'a> {
     pub create_acpi_table: bool,
     pub distribution: &'a str,
     pub qemu_version: Option<&'a str>,
+    pub patch_kernel: bool,
 }
 
 impl Machine<'_> {
@@ -54,7 +55,7 @@ impl Machine<'_> {
             let kernel_path = self.kernel.ok_or_else(|| anyhow::anyhow!("Kernel path required for direct boot"))?;
             let initrd_path = self.initrd.ok_or_else(|| anyhow::anyhow!("Initrd path required for direct boot"))?;
 
-            rtmr1 = kernel::measure_rtmr1_direct(kernel_path, initrd_path, self.memory_size, 0x28000)?;
+            rtmr1 = kernel::measure_rtmr1_direct(kernel_path, initrd_path, self.memory_size, 0x28000, self.patch_kernel)?;
             rtmr2 = kernel::measure_rtmr2_direct(initrd_path, self.kernel_cmdline)?;
 
         } else { // Indirect boot
@@ -99,7 +100,7 @@ impl Machine<'_> {
             let initrd_path = self.initrd.ok_or_else(|| anyhow::anyhow!("Initrd path required for direct boot"))?;
 
             // WARN : Carefull, when measuring the runtime only, we only compute the measurement for memory size > 0xb0000000
-            rtmr1 = kernel::measure_rtmr1_direct(kernel_path, initrd_path, 0xb0000000, 0x28000)?;
+            rtmr1 = kernel::measure_rtmr1_direct(kernel_path, initrd_path, 0xb0000000, 0x28000, self.patch_kernel)?;
             rtmr2 = kernel::measure_rtmr2_direct(initrd_path, self.kernel_cmdline)?;
 
         } else { // Indirect boot

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 use crate::tdvf::Tdvf;
-use crate::{kernel, image, TdxMeasurements};
+use crate::{ImageConfig, TdxMeasurements, image, kernel};
 use anyhow::{Context, Result};
 use fs_err as fs;
 use log::debug;
@@ -31,6 +31,7 @@ pub struct Machine<'a> {
     pub sbat_level: Option<&'a str>,
     pub direct_boot: bool,
     pub metadata_path: &'a Path,
+    pub image_config: Option<ImageConfig>,
     pub create_acpi_table: bool,
     pub distribution: &'a str,
     pub qemu_version: Option<&'a str>,

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -34,6 +34,11 @@ pub struct Machine<'a> {
     pub create_acpi_table: bool,
     pub distribution: &'a str,
     pub qemu_version: Option<&'a str>,
+    /// When set (together with `qemu_source_sha256`), build QEMU from this
+    /// source tarball URL (hash-verified) instead of the distribution package.
+    pub qemu_source_url: Option<&'a str>,
+    /// Expected SHA-256 (hex) of the `qemu_source_url` tarball.
+    pub qemu_source_sha256: Option<&'a str>,
     pub patch_kernel: bool,
 }
 

--- a/src/tdvf.rs
+++ b/src/tdvf.rs
@@ -9,7 +9,7 @@ use sha2::{Digest, Sha384};
 
 use crate::num::read_le;
 use crate::util::{debug_print_log, measure_sha384, measure_log, utf16_encode, read_file_data};
-use crate::Machine;
+use crate::{ImageConfig, Machine};
 
 const PAGE_SIZE: u64 = 0x1000;
 const MR_EXTEND_GRANULARITY: usize = 0x100;
@@ -268,7 +268,11 @@ impl<'a> Tdvf<'a> {
         let cfv_hash = self.measure_cfv().context("Failed to find CFV section")?;
 
         // Build ACPI tables
-        let tables = machine.build_tables()?;
+        let tables = if let Some(ImageConfig{boot_config: Some(boot_config),direct: _, indirect: _}) = &machine.image_config {
+            machine.build_tables_with_boot_config(boot_config)?
+        } else {
+            machine.build_tables()?
+        };
         let acpi_tables_hash = measure_sha384(&tables.tables);
         let acpi_rsdp_hash = measure_sha384(&tables.rsdp);
         let acpi_loader_hash = measure_sha384(&tables.loader);

--- a/src/tdvf.rs
+++ b/src/tdvf.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use sha2::{Digest, Sha384};
 
 use crate::num::read_le;
-use crate::util::{debug_print_log, measure_sha384, measure_log, utf16_encode, read_file_data};
+use crate::util::{debug_print_log, measure_log, measure_sha384, read_file_data, utf16_encode};
 use crate::{ImageConfig, Machine};
 
 const PAGE_SIZE: u64 = 0x1000;
@@ -64,7 +64,11 @@ fn encode_guid(guid_str: &str) -> Result<Vec<u8>> {
 }
 
 /// Measures an EFI variable event.
-fn measure_tdx_efi_variable(vendor_guid: &str, var_name: &str, var_data: Option<&[u8]>) -> Result<Vec<u8>> {
+fn measure_tdx_efi_variable(
+    vendor_guid: &str,
+    var_name: &str,
+    var_data: Option<&[u8]>,
+) -> Result<Vec<u8>> {
     let mut data = Vec::new();
     data.extend_from_slice(&encode_guid(vendor_guid)?);
     data.extend_from_slice(&(var_name.len() as u64).to_le_bytes());
@@ -268,7 +272,12 @@ impl<'a> Tdvf<'a> {
         let cfv_hash = self.measure_cfv().context("Failed to find CFV section")?;
 
         // Build ACPI tables
-        let tables = if let Some(ImageConfig{boot_config: Some(boot_config),direct: _, indirect: _}) = &machine.image_config {
+        let tables = if let Some(ImageConfig {
+            boot_config: Some(boot_config),
+            direct: _,
+            indirect: _,
+        }) = &machine.image_config
+        {
             machine.build_tables_with_boot_config(boot_config)?
         } else {
             machine.build_tables()?
@@ -299,7 +308,8 @@ impl<'a> Tdvf<'a> {
         if machine.direct_boot {
             // Boot0000 data for direct boot mode
             let boot0000_hex = "090100002c0055006900410070007000000004071400c9bdb87cebf8344faaea3ee4af6516a10406140021aa2c4614760345836e8ab6f46623317fff0400";
-            let boot0000 = hex::decode(boot0000_hex).context("Failed to decode boot0000 hex string")?;
+            let boot0000 =
+                hex::decode(boot0000_hex).context("Failed to decode boot0000 hex string")?;
             rtmr0_log.push(measure_sha384(&boot0000));
         } else {
             for boot_entry_num in boot_entries {
@@ -311,7 +321,11 @@ impl<'a> Tdvf<'a> {
 
         // Add SbatLevel if not direct boot
         if !machine.direct_boot {
-            rtmr0_log.push(measure_tdx_efi_variable("605DAB50-E046-4300-ABB6-3DD810DD8B23", "SbatLevel", Some(b"sbat,1,2021030218\n"))?);
+            rtmr0_log.push(measure_tdx_efi_variable(
+                "605DAB50-E046-4300-ABB6-3DD810DD8B23",
+                "SbatLevel",
+                Some(b"sbat,1,2021030218\n"),
+            )?);
         }
 
         debug_print_log("RTMR0", &rtmr0_log);

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -102,6 +102,7 @@ fn measure_platform_matches_expected_json_for_every_fixture() {
             .metadata_path(&metadata_path)
             .create_acpi_table(false)
             .distribution("")
+            .patch_kernel(true)
             .build();
 
         let m = machine


### PR DESCRIPTION
- Fix[RTMR1]: Fix for https://github.com/virtee/tdx-measure/issues/38 

- Enhancement[Essential]: The value of `serial` arg also affects the measurements, specifically rtmr0. So there needs to be an option to make it configurable under `boot_config.qemu` in metadata

- Enhancement[Essential]: The `Machine::measure()` function reads metadata from the file path. But when the project is consumed as a library it may be redundant to write the qemu config to a file and then having to read it back to launch a qemu VM for ACPI table generation. So this PR extends Machine to carry optional metadata in the ImageConfig format, and the needed adjustments to directly extract needed values from the image_config instead of reading from the file.

- Enhancement[Good to have]: An option to provide `qemu_source_url` and `qemu_source_sha256` as an alternative of qemu version pinning to allow upstream sources.

I am bundling all the enhancements together as all these changes were built one over the other. If you feel any of these changes are redundant, feel free to comment, I'll raise separate PRs.